### PR TITLE
fix TOPK.PRANGE DESC issue

### DIFF
--- a/src/topk.c
+++ b/src/topk.c
@@ -577,7 +577,7 @@ int TopKPRange_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
       RedisModule_ReplyWithString(ctx, ele);
     }
   } else {
-    for (i = Vector_Size(reply); i > 0; i--) {
+    for (i = Vector_Size(reply) - 1; i >= 0; i--) {
       Vector_Get(reply, i, &ele);
       RedisModule_ReplyWithString(ctx, ele);
     }


### PR DESCRIPTION
- for ASC it run correctly because it replies with vector[0] to vector[vector_size-1]
- for DESC it run not incorrectly as my previous comment because replies with vector[vector_size] to vector[1].

-> fixed DESC: replying with vector[vector_size-1] to vector[0]
